### PR TITLE
Fixed the 500 error when getting all rooms

### DIFF
--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -16,25 +16,28 @@ const Attempt = AttemptFactory(sequelize);
    SUCH THAT when I query USERS, completed room IDs show up. When I query ROOMS, I can see all
    USERS who completed it. */
 
+//    The 1-to-many association between User(Creator) and Room
    User.hasMany(Room, {
     foreignKey: 'creatorID', // The foreign key in the Room model referring to the User model
     as: 'roomsCreated', // Alias for rooms created by the user
   });
   
+  Room.belongsTo(User, { 
+      foreignKey: 'creatorID', // Room creator
+      as: 'Creator'
+  });
+
+//   The Many-to-many association between User(Player) and Room
   User.belongsToMany(Room, {
     through: 'Attempt', // Junction table for the many-to-many relationship
     foreignKey: 'userId',
     as: 'roomsCompleted', // Alias for rooms completed by the user
   });
 
-Room.belongsTo(User, { 
-    foreignKey: 'creatorID', // Room creator
-    as: 'Creator' 
-});
-
 Room.belongsToMany(User, {
     through: 'Attempt',
-    foreignKey: 'roomId'
+    foreignKey: 'roomId',
+    as: 'Player',
 });
 
 // A single room has many riddles

--- a/server/src/routes/api/roomRoutes.ts
+++ b/server/src/routes/api/roomRoutes.ts
@@ -10,8 +10,8 @@ router.get('/', async (_req: Request, res: Response) => {
     try {
         const rooms = await Room.findAll({
             include: [
-                { model: User, as: 'creator' }, // Adjusted alias to match model definition
-                { model: User, as: 'player'}, // Example alias for participants, adjust as necessary
+                { model: User, as: 'Creator' }, // Adjusted alias to match model definition
+                { model: User, as: 'Player'}, // Example alias for participants, adjust as necessary
                 { model: Riddle, as: 'riddles' } // Ensure alias matches model definition
             ],
         });
@@ -29,7 +29,7 @@ router.get('/:id', async (req: Request, res: Response) => {
         const room = await Room.findByPk(roomId, {
             include: [
                 { model: User, as: 'Creator' }, // Correct alias for the user who created the room
-                { model: User }, // This assumes there is a many-to-many association for users
+                { model: User, as: 'Player' }, // This assumes there is a many-to-many association for users
                 { model: Riddle, as: 'riddles' }
             ],
         });

--- a/server/src/routes/api/userRoutes.ts
+++ b/server/src/routes/api/userRoutes.ts
@@ -64,8 +64,10 @@ router.get('/:id', async (req: Request, res: Response) => {
     try {
         const user = await User.findByPk(id, {
             include: [
+                // These lines of code are causing the 500 error
                 { model: Room, as: 'rooms' }, // Alias for the rooms the user has participated in
                 { model: Room, as: 'roomsCreated' } // Alias for the rooms the user has created
+                // -----------
             ],
             attributes: { exclude: ['password'] },
         });


### PR DESCRIPTION
Models/index: made the associations between User and Room easier to read. Added "player" alias to the many-to-many between User and Room
roomRoutes: changed casing on some aliases. Added the "player" alias to finding Room by ID
userRoutes: Identified the cause of the 500 error when getting a user by id